### PR TITLE
update links for workshop 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,71 @@
-# Hackathon Prep
-Agenda for hackathon training using Watson Developer Cloud APIs and IBM Cloud. 
+# Watson Hackathon
 
-## Training Agenda
+Agenda for hackathon training using Watson APIs and IBM Cloud.
 
-## Workshop 1 - Intro to Watson Developer Cloud APIs
-* 2:30-3:30 
-  * Visual Recognition
+## Workshop 1A - Intro to Watson APIs
+
+* Visual Recognition
   * Video: https://www.youtube.com/watch?v=n3_oGnXkMAE
   * Demo: https://www.ibm.com/watson/services/visual-recognition/demo/#demo
-  * Overview: https://www.ibm.com/watson/developercloud/visual-recognition.html
+  * Learning Path: https://developer.ibm.com/series/learning-path-watson-visual-recognition
+* Watson Discovery
+  * Video: https://www.youtube.com/watch?v=9ks-cEG6KPs
+  * Demo: https://discovery-news-demo.ng.bluemix.net
+  * Learning Path: https://developer.ibm.com/series/learning-path-watson-discovery
+* Watson Assistant 
+  * Video: https://www.youtube.com/watch?v=xdGaynxnt4M
+  * Demo: https://watson-assistant-demo.ng.bluemix.net/
+  * Learning Path: https://developer.ibm.com/series/learning-path-watson-assistant
 * Watson Natural Language Understanding
   * Video: https://www.youtube.com/watch?v=MB4ynlq52C4
-  * Demo: https://natural-language-understanding-demo.mybluemix.net/ 
+  * Demo: https://natural-language-understanding-demo.ng.bluemix.net
+* Watson Natural Language Classifier
+  * Video: https://www.youtube.com/watch?v=h1ZiUIvYdD8
+  * Demo: https://natural-language-classifier-demo.ng.bluemix.net
 * Watson Speech-to-Text/Text-to-Speech
-  * Demo: https://text-to-speech-demo.mybluemix.net/
-  * Demo: https://speech-to-text-demo.mybluemix.net/
-* Watson Language Translation 
+  * Demo: https://text-to-speech-demo.ng.bluemix.net
+  * Demo: https://speech-to-text-demo.ng.bluemix.net
+* Watson Language Translator 
   * Video: https://www.youtube.com/watch?v=bYtVaQxJ994
-  * Demo: https://language-translator-demo.ng.bluemix.net/
-* Watson Discovery
-  * Video: https://youtu.be/9ks-cEG6KPs
-  * Demo: https://discovery-news-demo.mybluemix.net/
-* Watson Assistant 
-  * Video: https://www.youtube.com/watch?v=xdGaynxnt4M&t=4s
-  * Demo: https://watson-assistant-demo.ng.bluemix.net/
-* Tone Analyzer 
+  * Demo: https://language-translator-demo.ng.bluemix.net
+* Watson Tone Analyzer
   * Video: https://www.youtube.com/watch?v=wUb--6FPBik
-  * Demo: https://tone-analyzer-demo.mybluemix.net/
+  * Demo: https://tone-analyzer-demo.ng.bluemix.net
 * Watson Personality Insights
   * Video: https://www.youtube.com/watch?v=YdVVLWv3Fwo
-  * Demo: https://personality-insights-livedemo.mybluemix.net/
-* Natural Language Classifier
-  * Video: https://www.youtube.com/watch?v=h1ZiUIvYdD8&feature=youtu.be
-  * Demo: https://natural-language-classifier-demo.mybluemix.net/
-* Watson Natural Language Translator 
-  * Video: https://www.youtube.com/watch?v=bYtVaQxJ994 
-  * Demo: https://language-translator-demo.mybluemix.net/?cm_mc_uid=36152158407015012554435&cm_mc_sid_50200000=1509816451&cm_mc_sid_52640000=1509816451
+  * Demo: https://personality-insights-demo.ng.bluemix.net
   
-  ## Watson Studio and Watson ML 
+## Workshop 1B - Watson Studio and Watson Maching Learning
 
 * Watson Studio
-  * Video: https://www.youtube.com/watch?v=1HjzkLRdP5k
-  * Documentation: https://dataplatform.cloud.ibm.com/docs/content/wsj/getting-started/welcome-main.html?context=analytics
+  * Video: https://www.youtube.com/watch?v=MfH6T6J1_Jo
+  * Documentation: https://dataplatform.cloud.ibm.com/docs/content/wsj/getting-started/welcome-main.html
+  * Learning Path: https://developer.ibm.com/series/learning-path-watson-studio/
 * Watson Machine Learning
   * Video: https://www.youtube.com/watch?v=1A-HZwK8u0w
   * Documentation: https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-overview.html
 
-  
 ## Workshop 2 - Hands-on Labs for Watson Visual Recognition and Natural Language Understanding
 
-* Sign up for IBM Cloud here: https://cloud.ibm.com/login
-* Labs
-  * Set-up node red instructions: https://nodered.org/docs/getting-started/ibmcloud#boilerplate-application
-  * Node Red Tutorial Watson Natural Language Understanding Lab: https://github.com/jeancarl/node-red-labs/blob/master/node-red-natural-language-understanding/node-red-natural-language-understanding.pdf
-    OR 
-  * Visual Recognition Lab with Node Red: https://medium.com/@helenflam/quickly-exploring-the-visual-recognition-api-using-node-red-db11680bf69
-    OR 
-  * Second option for Visual Recognition API, train your own custom image classification model using Watson Studio: https://github.com/IBM/drones-iot-visual-recognition
-    OR 
-  * Use Tone Analyzer to analyze earning calls transcript
-  https://github.com/djccarew/watson-toneanalyzer-nlu-lab
-    OR
-  * Watson Discovery tutorial: https://www.ibm.com/cloud/garage/tutorials/cognitive_discovery/
+> **IMPORTANT**: Log into IBM Cloud (https://cloud.ibm.com/login) or register (https://cloud.ibm.com/registration)
+
+### Labs
+
+* Set-up node red instructions: https://nodered.org/docs/getting-started/ibmcloud#boilerplate-application
+* Node Red Tutorial Watson Natural Language Understanding Lab: https://github.com/jeancarl/node-red-labs/blob/master/node-red-natural-language-understanding/node-red-natural-language-understanding.pdf
+  OR
+* Visual Recognition Lab with Node Red: https://medium.com/@helenflam/quickly-exploring-the-visual-recognition-api-using-node-red-db11680bf69
+  OR
+* Second option for Visual Recognition API, train your own custom image classification model using Watson Studio: https://github.com/IBM/drones-iot-visual-recognition
+  OR
+* Use Tone Analyzer to analyze earning calls transcript
+https://github.com/djccarew/watson-toneanalyzer-nlu-lab
+  OR
+* Watson Discovery tutorial: https://www.ibm.com/cloud/garage/tutorials/cognitive_discovery/
 
 ## Important Links - Watson sample code and tutorials
-* A.I. Code Patterns: https://developer.ibm.com/patterns/category/artificial-intelligence/?fa=date%3ADESC&fb=
+
+* A.I. Code Patterns: https://developer.ibm.com/patterns/category/artificial-intelligence/
 * Watson tutorials, & example applications: https://medium.com/ibm-watson-developer-cloud
 * Watson Starter Kits: https://cloud.ibm.com/developer/watson/starter-kits
 * Watson Documentation: https://www.ibm.com/watson/developercloud/doc/index.html
@@ -73,20 +74,19 @@ Agenda for hackathon training using Watson Developer Cloud APIs and IBM Cloud.
 ## Cloud Deployment Options - Kubernetes and Cloud Foundry
 
 1. Install CLI [here](https://cloud.ibm.com/docs/cli/reference/ibmcloud?topic=cloud-cli-install-ibmcloud-cli)
-2. Cloud Foundry [Node JS docs](https://cloud.ibm.com/docs/runtimes/nodejs?topic=Nodejs-getting-started#getting-started), [Java with Liberty](https://cloud.ibm.com/docs/runtimes/liberty?topic=liberty-getting-started#getting-started), [Python](https://cloud.ibm.com/docs/runtimes/python?topic=Python-getting_started#getting_started), [Go](https://cloud.ibm.com/docs/runtimes/go/getting-started.html#getting-started), [Swift](https://cloud.ibm.com/catalog/starters/runtime-for-swift), & [Ruby-on-Rails](https://cloud.ibm.com/docs/runtimes/ruby?topic=Ruby-getting_started#getting_started)
-Note: In addition, Tomcat, .net, and PHP runtime supported and can find documentation [here](https://cloud.ibm.com/catalog?search=cloud%20foundry)
+2. Cloud Foundry Runtimes:
+   * [Node JS docs](https://cloud.ibm.com/docs/runtimes/nodejs?topic=Nodejs-getting-started#getting-started)
+   * [Java with Liberty](https://cloud.ibm.com/docs/runtimes/liberty?topic=liberty-getting-started#getting-started)
+   * [Python](https://cloud.ibm.com/docs/runtimes/python?topic=Python-getting_started#getting_started)
+   * [Go](https://cloud.ibm.com/docs/runtimes/go/getting-started.html#getting-started)
+   * [Swift](https://cloud.ibm.com/catalog/starters/runtime-for-swift)
+   * [Ruby-on-Rails](https://cloud.ibm.com/docs/runtimes/ruby?topic=Ruby-getting_started#getting_started)
+   * **NOTE**: In addition, Tomcat, .net, and PHP runtime supported and can find documentation [here](https://cloud.ibm.com/catalog?search=cloud%20foundry)
+
 3. OR use Kubernetes to deploy if you can't find your runtime, Kube 101 [here](https://github.com/IBM/kube101/tree/master/workshop)
 
 4. EXTRA FYI, Kubernetes vs. Cloud Foundry: https://developer.ibm.com/blogs/game-of-cloud-technologies-kubernetes-vs-cloud-foundry/
 
-## Contact Info 
-* Helen.lam@ibm.com | @helennnsays 
+## Contact Info
 
-
-
-
-
-
-
-
-
+* [helen.lam@ibm.com](helen.lam@ibm.com) | [@helennnsays](http://twitter.com/helennnsays)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Agenda for hackathon training using Watson APIs and IBM Cloud.
 
 2. Choose between Cloud Foundry or Kubernetes. [Read about the pros and cons of Cloud Foundry vs Kuberenetes](https://developer.ibm.com/blogs/game-of-cloud-technologies-kubernetes-vs-cloud-foundry/)
 
-3A. Cloud Foundry Runtimes:
+3. Cloud Foundry Runtimes:
    * [Node JS](https://cloud.ibm.com/docs/runtimes/nodejs?topic=Nodejs-getting-started#getting-started)
    * [Java with Liberty](https://cloud.ibm.com/docs/runtimes/liberty?topic=liberty-getting-started#getting-started)
    * [Python](https://cloud.ibm.com/docs/runtimes/python?topic=Python-getting_started#getting_started)
@@ -88,7 +88,7 @@ Agenda for hackathon training using Watson APIs and IBM Cloud.
    * [Ruby-on-Rails](https://cloud.ibm.com/docs/runtimes/ruby?topic=Ruby-getting_started#getting_started)
    * Tomcat, .NET, and PHP runtime support can be found in [IBM Cloud Documentation](https://cloud.ibm.com/catalog?search=cloud%20foundry)
 
-3B. Use Kubernetes to deploy using containers. Follow the [Kube 101 Workshop](https://github.com/IBM/kube101/tree/master/workshop)
+4. Use Kubernetes to deploy using containers. Follow the [Kube 101 Workshop](https://github.com/IBM/kube101/tree/master/workshop)
 
 ## Contact Info
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Agenda for hackathon training using Watson APIs and IBM Cloud.
 
 ### Labs
 
-* Assistant: https://github.com/lidderupk/watson-assistant-restaurant
+* Assistant: https://cloud.ibm.com/docs/services/assistant?topic=assistant-getting-started#getting-started
 
 * Visual Recognition (Create your own custom model): https://github.com/IBM/drones-iot-visual-recognition
 
@@ -76,18 +76,19 @@ Agenda for hackathon training using Watson APIs and IBM Cloud.
 ## Cloud Deployment Options - Kubernetes and Cloud Foundry
 
 1. Install CLI [here](https://cloud.ibm.com/docs/cli/reference/ibmcloud?topic=cloud-cli-install-ibmcloud-cli)
-2. Cloud Foundry Runtimes:
-   * [Node JS docs](https://cloud.ibm.com/docs/runtimes/nodejs?topic=Nodejs-getting-started#getting-started)
+
+2. Choose between Cloud Foundry or Kubernetes. [Read about the pros and cons of Cloud Foundry vs Kuberenetes](https://developer.ibm.com/blogs/game-of-cloud-technologies-kubernetes-vs-cloud-foundry/)
+
+3A. Cloud Foundry Runtimes:
+   * [Node JS](https://cloud.ibm.com/docs/runtimes/nodejs?topic=Nodejs-getting-started#getting-started)
    * [Java with Liberty](https://cloud.ibm.com/docs/runtimes/liberty?topic=liberty-getting-started#getting-started)
    * [Python](https://cloud.ibm.com/docs/runtimes/python?topic=Python-getting_started#getting_started)
    * [Go](https://cloud.ibm.com/docs/runtimes/go/getting-started.html#getting-started)
    * [Swift](https://cloud.ibm.com/catalog/starters/runtime-for-swift)
    * [Ruby-on-Rails](https://cloud.ibm.com/docs/runtimes/ruby?topic=Ruby-getting_started#getting_started)
-   * **NOTE**: In addition, Tomcat, .net, and PHP runtime supported and can find documentation [here](https://cloud.ibm.com/catalog?search=cloud%20foundry)
+   * Tomcat, .NET, and PHP runtime support can be found in [IBM Cloud Documentation](https://cloud.ibm.com/catalog?search=cloud%20foundry)
 
-3. OR use Kubernetes to deploy if you can't find your runtime, Kube 101 [here](https://github.com/IBM/kube101/tree/master/workshop)
-
-4. EXTRA FYI, Kubernetes vs. Cloud Foundry: https://developer.ibm.com/blogs/game-of-cloud-technologies-kubernetes-vs-cloud-foundry/
+3B. Use Kubernetes to deploy using containers. Follow the [Kube 101 Workshop](https://github.com/IBM/kube101/tree/master/workshop)
 
 ## Contact Info
 

--- a/README.md
+++ b/README.md
@@ -45,23 +45,25 @@ Agenda for hackathon training using Watson APIs and IBM Cloud.
   * Video: https://www.youtube.com/watch?v=1A-HZwK8u0w
   * Documentation: https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-overview.html
 
-## Workshop 2 - Hands-on Labs for Watson Visual Recognition and Natural Language Understanding
+## Workshop 2 - Hands-on Labs
 
 > **IMPORTANT**: Log into IBM Cloud (https://cloud.ibm.com/login) or register (https://cloud.ibm.com/registration)
 
 ### Labs
 
-* Set-up node red instructions: https://nodered.org/docs/getting-started/ibmcloud#boilerplate-application
-* Node Red Tutorial Watson Natural Language Understanding Lab: https://github.com/jeancarl/node-red-labs/blob/master/node-red-natural-language-understanding/node-red-natural-language-understanding.pdf
-  OR
-* Visual Recognition Lab with Node Red: https://medium.com/@helenflam/quickly-exploring-the-visual-recognition-api-using-node-red-db11680bf69
-  OR
-* Second option for Visual Recognition API, train your own custom image classification model using Watson Studio: https://github.com/IBM/drones-iot-visual-recognition
-  OR
-* Use Tone Analyzer to analyze earning calls transcript
-https://github.com/djccarew/watson-toneanalyzer-nlu-lab
-  OR
-* Watson Discovery tutorial: https://www.ibm.com/cloud/garage/tutorials/cognitive_discovery/
+* Assistant: https://github.com/lidderupk/watson-assistant-restaurant
+
+* Visual Recognition (Create your own custom model): https://github.com/IBM/drones-iot-visual-recognition
+
+* Tone Analyzer (Analyze earning calls transcript): https://github.com/djccarew/watson-toneanalyzer-nlu-lab
+
+* Discovery: https://www.ibm.com/cloud/garage/tutorials/cognitive_discovery/
+
+* Watson Natural Language Understanding (with Node-RED): https://github.com/jeancarl/node-red-labs/blob/master/node-red-natural-language-understanding/node-red-natural-language-understanding.pdf
+
+* Visual Recognition (with Node-RED): https://medium.com/@helenflam/quickly-exploring-the-visual-recognition-api-using-node-red-db11680bf69
+
+> **IMPORTANT**: Instructions for setting up Node-RED: https://nodered.org/docs/getting-started/ibmcloud#boilerplate-application
 
 ## Important Links - Watson sample code and tutorials
 


### PR DESCRIPTION
I went through the links in workshop 1 and noticed/updated a few things:

* language translator was listed twice.
* moved assistant/discovery at the top
* some URLs were redirecting, so I update the link to the redirected one
* added learning paths to VizRec/Assistant/Disco since we just released those
* some formatting changes to the document (titles, bullets, linking)